### PR TITLE
fix(*): ensume web3 module requiring is in lowercase

### DIFF
--- a/test/helpers/MetricSetHasher.js
+++ b/test/helpers/MetricSetHasher.js
@@ -1,4 +1,4 @@
-import Web3 from 'Web3';
+import Web3 from 'web3';
 import leftPad from 'left-pad';
 import { isString, isNumber, forEach } from 'lodash';
 


### PR DESCRIPTION
When following instructions to simulate voting on an election
this `require` raised an error `Cannot find module 'Web3'`