### PR TITLE
feat(elections): adding blinded proposals

### DIFF
--- a/contracts/Chain.sol
+++ b/contracts/Chain.sol
@@ -26,7 +26,9 @@ contract Chain is Ownable {
     address _registryAddress,
     uint256 _startsAt,
     uint256 _endsAt,
-    bytes32 _root
+    bytes32 _root,
+    uint256 _votingTime,
+    uint256 _revealTime
   ) public onlyOwner {
     Election election = new Election(
       _registryAddress,
@@ -35,7 +37,9 @@ contract Chain is Ownable {
       block.number,
       _root,
       _startsAt,
-      _endsAt
+      _endsAt,
+      _votingTime,
+      _revealTime
     );
 
     authorize(election);

--- a/contracts/Election.sol
+++ b/contracts/Election.sol
@@ -11,6 +11,7 @@ contract Election is ReentrancyGuard {
   address public chainAddress;
   mapping(address => Voter) public voters;
   address[] public addresses;
+  mapping(bytes32 => bool) public blindedProposals;
   uint blockNumber;
   mapping(uint256 => mapping(bytes32 => uint256)) counts;
   bytes32 public previousRoot;
@@ -19,12 +20,19 @@ contract Election is ReentrancyGuard {
   uint256 public endsAt;
   bool public counted;
   bool public revealed;
+  uint256 votingEnd;
+  uint256 revealEnd;
 
   struct Voter {
     bool voted;
-    bytes32 proposal;
+    bytes32 blindedProposal;
     uint256 shard;
+    bytes32 proposal;
+    bool revealed;
   }
+
+  modifier onlyBefore(uint _time) { if (now >= _time) throw; _; }
+  modifier onlyAfter(uint _time) { if (now <= _time) throw; _; }
 
   function Election(
     address _registryAddress,
@@ -33,7 +41,9 @@ contract Election is ReentrancyGuard {
     uint _blockNumber,
     bytes32 _previousRoot,
     uint256 _startsAt,
-    uint256 _endsAt
+    uint256 _endsAt,
+    uint256 _votingTime,
+    uint _revealTime
   ) {
     registryAddress = _registryAddress;
     chainAddress = _chainAddress;
@@ -42,36 +52,63 @@ contract Election is ReentrancyGuard {
     previousRoot = _previousRoot;
     startsAt = _startsAt;
     endsAt = _endsAt;
+    votingEnd = now + _votingTime;
+    revealEnd = votingEnd + _revealTime;
   }
 
   function getNumberOfVerifiers() public view returns (uint) {
     return addresses.length;
   }
 
-  function vote(bytes32 _proposal) external nonReentrant {
-    require(block.number - 2 == blockNumber); // only allow voting for one block
+  /*
+   * each operator/verifier submits an encrypted proposal
+   * each proposal is unique to avoid proposal peeking
+   */
+  function vote(bytes32 _blindedProposal) onlyBefore(votingEnd) external nonReentrant {
     Voter sender = voters[msg.sender];
     require(!sender.voted);
+    require(!blindedProposals[_blindedProposal]);
 
     Registrations registry = Registrations(registryAddress);
     var (id, location, created, balance, shard) = registry.verifiers(msg.sender);
     require(created);
 
-    sender.proposal = _proposal;
+    sender.blindedProposal = _blindedProposal;
     sender.voted = true;
     sender.shard = shard;
     addresses.push(msg.sender);
   }
 
-  function count() external nonReentrant {
+  /*
+   * operators/verifiers must provide the secret used to encrypt their proposal
+   */
+  function reveal(bytes32 _proposal, bytes32 _secret)
+    onlyAfter(votingEnd)
+    onlyBefore(revealEnd)
+    external nonReentrant {
+    Voter sender = voters[msg.sender];
+    require(sender.voted);
+    require(!sender.revealed);
+
+    var proof = keccak256(_proposal, _secret);
+    require(sender.blindedProposal == proof);
+
+    sender.proposal = _proposal;
+    sender.revealed = true;
+  }
+
+  /*
+   * once all proposals have been revealed we can go count them and determine the winners
+   */
+  function count() onlyAfter(revealEnd) external nonReentrant {
     require(msg.sender == chairperson);
-    require(block.number - 2 > blockNumber);
     require(!counted);
 
     uint256[] maxs;
 
     for (uint256 i = 0; i < addresses.length; i++) {
       Voter voter = voters[addresses[i]];
+      if (!voter.revealed) { continue; }
       counts[voter.shard][voter.proposal] += 1;
 
       if (counts[voter.shard][voter.proposal] >= maxs[voter.shard]) {

--- a/test/helpers/Hasher.js
+++ b/test/helpers/Hasher.js
@@ -1,0 +1,31 @@
+import Web3 from 'web3';
+import leftPad from 'left-pad';
+import { isString, isNumber, forEach } from 'lodash';
+
+const web3 = new Web3(new Web3.providers.HttpProvider("http://localhost:8545"));
+
+function keccak256(...args) {
+  var hexStart = '0x';
+
+  args = args.map(arg => {
+    if (isString(arg)) {
+      if (arg.substring(0, 2) === hexStart) {
+          return arg.slice(2)
+      } else {
+          return web3.toHex(arg).slice(2)
+      }
+    }
+
+    if (isNumber(arg)) {
+      return leftPad((arg).toString(16), 64, 0)
+    } else {
+      return ''
+    }
+  });
+
+  args = args.join('');
+
+  return web3.sha3(args, {encoding: 'hex'});
+}
+
+module.exports.keccak256 = keccak256;

--- a/test/helpers/MetricSetHasher.js
+++ b/test/helpers/MetricSetHasher.js
@@ -1,38 +1,15 @@
 import Web3 from 'web3';
 import leftPad from 'left-pad';
 import { isString, isNumber, forEach } from 'lodash';
+import Hasher from './Hasher.js';
 
 const web3 = new Web3(new Web3.providers.HttpProvider("http://localhost:8545"));
 
-function keccak256(...args) {
-  var hexStart = '0x';
-
-  args = args.map(arg => {
-    if (isString(arg)) {
-      if (arg.substring(0, 2) === hexStart) {
-          return arg.slice(2)
-      } else {
-          return web3.toHex(arg).slice(2)
-      }
-    }
-
-    if (isNumber(arg)) {
-      return leftPad((arg).toString(16), 64, 0)
-    } else {
-      return ''
-    }
-  });
-
-  args = args.join('');
-
-  return web3.sha3(args, {encoding: 'hex'});
-}
-
 function call(root, rows) {
-  var hash = keccak256(root);
+  var hash = Hasher.keccak256(root);
 
   _.forEach(rows, (row) => {
-    hash = keccak256(
+    hash = Hasher.keccak256(
       hash,
       row['campaign_id'],
       row['channel_id'],


### PR DESCRIPTION
Implements blind voting to improve the Andromeda consensus mechanism.
Instead of listening for proposals at a given block number, there is now a voting period and a reveal period defined in seconds.
Withing the voting period operators can submit blinded proposals which are generated by using a random secret.
All operators will submit unique hashes to avoid looking at other people's votes.
When the voting period is over, operators reveal the raw proposal and the secret used to generate the blind proposal.

Once all votes have been revealed, the normal count process takes places.
Currently, count is a Proof of Authority mechanism that allows registry operators to participate in consensus.
All raw proposals are counted and the proposal with the most votes is claimed as the winning proposal.

Block explorers may then use the winning proposal to verify validity of the data which is queried from the winning operators.

See: http://solidity.readthedocs.io/en/v0.3.1/solidity-by-example.html
ENG-325