### PR TITLE
feat(chain): add initial block-height per shard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - option to update `minimumStakingTokenPercentage`.
+- `initialBlockHeights` to set the initial block-height per shard
 
 ### Changed
-- when verifier proposing, `Chain` checks, if verifier is active instead 
+- when verifier proposing, `Chain` checks, if verifier is active instead
   of if it is only created.
 
 ## [0.3.0] - 2018-12-13
@@ -27,7 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Chain interface
 - Getters for reading `blocks` structure
 - update of contract code to be consistent with Solidity 0.4.24
-- Remove commissioner and introduce election cycle with two phases: propose and reveal 
+- Remove commissioner and introduce election cycle with two phases: propose and reveal
 
 ## [0.1.0] - 2018-04-12
 ### Added:

--- a/contracts/Chain.sol
+++ b/contracts/Chain.sol
@@ -61,6 +61,9 @@ contract Chain is ChainConfig, ReentrancyGuard {
   /// @dev blockHeight => Block - results of each elections will be saved here: one block (array element) per election
   mapping (uint256 => Block) blocks;
 
+  /// @dev shard => blockHeight
+  mapping (uint256 => uint256) public initialBlockHeights;
+
   constructor (
     address _registryAddress,
     uint8 _blocksPerPhase,
@@ -110,6 +113,10 @@ contract Chain is ChainConfig, ReentrancyGuard {
     voter.blindedProposal = _blindedProposal;
     voter.shard = shard;
     voter.balance = balance;
+
+    if (initialBlockHeights[shard] == 0) {
+      initialBlockHeights[shard] = blockHeight;
+    }
 
     emit LogPropose(msg.sender, blockHeight, _blindedProposal, shard, balance);
 


### PR DESCRIPTION
Add public variable to keep track of the
initial block-height of a contract.

Currently, the client does not know how
far back to check for the  validity of
previous elections.