### PR TITLE
feat(*): flexible duration of election phases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - when verifier proposing, `Chain` checks, if verifier is active instead
   of if it is only created.
 - split Chain contract into two separate contracts (storage and manager)
+- Flexible duration of election phases
 
 ## [0.3.0] - 2018-12-13
 ### Added:

--- a/contracts/ChainStorage.sol
+++ b/contracts/ChainStorage.sol
@@ -46,17 +46,28 @@ contract ChainStorage is StorageBase {
 
   bool public updateMinimumStakingTokenPercentageEnabled;
 
-  uint8 public blocksPerPhase;
+  uint8 public blocksPerPropose;
+  uint8 public blocksPerReveal;
 
   uint8 public minimumStakingTokenPercentage;
 
-  event LogChainConfig(uint8 blocksPerPhase, uint8 requirePercentOfTokens, bool updateMinimumStakingTokenPercentageEnabled);
+  event LogChainConfig(
+    uint8 blocksPerPropose,
+    uint8 blocksPerReveal,
+    uint8 requirePercentOfTokens,
+    bool updateMinimumStakingTokenPercentageEnabled
+  );
 
-  constructor(uint8 _blocksPerPhase,
+  constructor(
+    uint8 _blocksPerPropose,
+    uint8 _blocksPerReveal,
     uint8 _minimumStakingTokenPercentage,
     bool _updateMinimumStakingTokenPercentageEnabled) public {
-    require(_blocksPerPhase > 0, "_blocksPerPhase can't be empty");
-    blocksPerPhase = _blocksPerPhase;
+    require(_blocksPerPropose > 0, "_blocksPerPhase can't be empty");
+    require(_blocksPerReveal > 0, "_blocksPerReveal can't be empty");
+
+    blocksPerPropose = _blocksPerPropose;
+    blocksPerReveal = _blocksPerReveal;
 
     require(_minimumStakingTokenPercentage > 0, "_minimumStakingTokenPercentage can't be empty");
     require(_minimumStakingTokenPercentage <= 100, "_minimumStakingTokenPercentage can't be over 100%");
@@ -64,7 +75,12 @@ contract ChainStorage is StorageBase {
 
     updateMinimumStakingTokenPercentageEnabled = _updateMinimumStakingTokenPercentageEnabled;
 
-    emit LogChainConfig(_blocksPerPhase, _minimumStakingTokenPercentage, _updateMinimumStakingTokenPercentageEnabled);
+    emit LogChainConfig(
+      _blocksPerPropose,
+      _blocksPerReveal,
+      _minimumStakingTokenPercentage,
+      _updateMinimumStakingTokenPercentageEnabled
+    );
   }
 
   function getInitialBlockHeight(uint256 _shard) public view returns (uint256) {
@@ -160,6 +176,22 @@ contract ChainStorage is StorageBase {
     return true;
   }
 
+  function updatePhasesDurations(uint8 _blocksPerPropose, uint8 _blocksPerReveal)
+  external
+  onlyFromStorageOwner
+  returns (bool) {
+    require(_blocksPerPropose > 0, "_blocksPerPropose can't be empty");
+    require(_blocksPerReveal > 0, "_blocksPerReveal can't be empty");
+    require(blocksPerPropose + blocksPerReveal == _blocksPerPropose + _blocksPerReveal, "election duration must be fixed");
+
+    blocksPerPropose = _blocksPerPropose;
+    blocksPerReveal = _blocksPerReveal;
+
+    emit LogChainConfig(blocksPerPropose, blocksPerReveal, minimumStakingTokenPercentage, true);
+
+    return true;
+  }
+
   function updateMinimumStakingTokenPercentage(uint8 _minimumStakingTokenPercentage)
   external
   onlyFromStorageOwner
@@ -170,7 +202,7 @@ contract ChainStorage is StorageBase {
     require(_minimumStakingTokenPercentage <= 100, "_minimumStakingTokenPercentage can't be over 100%");
     minimumStakingTokenPercentage = _minimumStakingTokenPercentage;
 
-    emit LogChainConfig(blocksPerPhase, _minimumStakingTokenPercentage, true);
+    emit LogChainConfig(blocksPerPropose, blocksPerReveal, _minimumStakingTokenPercentage, true);
 
     return true;
   }


### PR DESCRIPTION
Add option to change duration of the phases inside election.
Restriction is, that total election duration must stay the same.

Currently we have even phase duration - but this is only in theory.
In reality we spending 2 block of `propose` phase waiting for confirmation, then we spend time to prepare data. All this make propose phase much shorter for validator.

Having option to change ratio of propose/reveal makes event chances for both transactions to be mined on time.

My recommendation will be  13/7 or 14/6. 

Another speed improvement will be to do small change into validator: instead start reveal on `reveal_start_block` we can send tx on previous block, because if it be mined in next block it will be first reveal block - this will give us additional time for propose.
