### PR TITLE
Hotfix [0.5.1] - 2020-01-27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.5.1] - 2020-01-27
+### Changed
+- when updating contract via `ContractRegistry`, old `Chain` contract is not killed
+
+### Fix
+- use `ContractRegistry` v0.1.1 to prevent storage locking
+
 ## [0.5.0] - 2019-10-29
 ### Added
 - flattener script

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The proposing and reveal round are each roughly 30 minutes.
 
 * Election has two phases: propose and reveal. Duration of each is: N blocks.
 * Phases going cycle, every `N * 2` blocks new cycle start.
-* Noone is in charge of starting phases, its self-controlled mechanism.   
+* Noone is in charge of starting phases, its self-controlled mechanism.
 * Each election root results are save to a block and kept on `Chain` contract at `blockHeight` index.
 
 ## Development
@@ -83,20 +83,20 @@ of verifiers for performing tests. Please run this test against different values
 If you experience above issue during coverage test, then create file
 `touch ./allFiredEvents` each time before you run test command, it should help.
 
-* Test hang/freeze during execution  
+* Test hang/freeze during execution
 
 I think this might be connected to the fact, that we mining a lot during tests
-to move from one to next phase. If this will happen, just cancel the test and run again.    
+to move from one to next phase. If this will happen, just cancel the test and run again.
 
 ### Testing on testnet
 
 This is tricky part, because you don't have access to build-in accounts full of ETH :)
-You need to create accounts or use coinbase.   
+You need to create accounts or use coinbase.
 
 Along with truffle console, you can use Ethereum wallet.
 It allows you to watch contracts (base on provided address and abi).
 It will display you all events, help you use getter functions and also
-it will show you in real time current cycle block - this is helpful.  
+it will show you in real time current cycle block - this is helpful.
 Below some example screen, how it look like in Ethereum wallet:
 
  ![chain view](./eth-wallet-chain.png)
@@ -117,7 +117,7 @@ var registry = VerifierRegistry.at(registryAddr);
 var chain = Chain.at(chainAddr);
 var humanToken = HumanStandardToken.at(tokenAddr);
 
-# you can use any account as long as you can unlock it  
+# you can use any account as long as you can unlock it
 var verifier = eth.web3.accounts[0];
 registry.create('name', 192.168.8.8', { from: verifier }));
 ```
@@ -155,7 +155,7 @@ chain.getBlockRoot(255311,0);
 
 ### Deployment
 
-For Test Net you can simple use this:  
+For Test Net you can simple use this:
 ```
 truffle deploy --network staging
 ```
@@ -174,19 +174,19 @@ It will be much much faster and cheaper.
 
 #### Ropsten contracts
 
-* development
-[0x91d8746c3d25dec812bec7082870e6c765ef9c31](https://ropsten.etherscan.io/address/0x17ffd54f82482858bcea63d4e54a941c24d9e5b0#readContract)
+Current contract address can be resolved by `ContractRegistry`:
 * staging
-[0xfb97e68081faec9b2105a07fccd11306f3150acd](https://ropsten.etherscan.io/address/0xb3df87beb7035f551709aa6bde7daa4e13ce1e51#readContract)
+[0x0e45f3c9fa762b260f13211711f57f007b2a723d](https://ropsten.etherscan.io/address/0x0e45f3c9fa762b260f13211711f57f007b2a723d#readContract)
 * production
-[0xd370f07ec82fd3615b19d912244a459c02c7625d](https://ropsten.etherscan.io/address/0xb3b060d8f67be00b09734c67edc5198f0d3162fe#readContract)
+[0x8b16f249b31563921781dd3c1b6ea9f5c47b4c33](https://ropsten.etherscan.io/address/0x8b16f249b31563921781dd3c1b6ea9f5c47b4c33#readContract)
 
+`Chain` name in `bytes32` is `0x436861696e000000000000000000000000000000000000000000000000000000`
 
 #### Code verification
 
-1. run `truffle-flattener ./contracts/Chain.sol > all.sol` to combined solidity file.  
+1. run `truffle-flattener ./contracts/Chain.sol > all.sol` to combined solidity file.
  Review the file ie: you can remove pragma repetition,
- you can add some comments if you like.  
+ you can add some comments if you like.
 1. Use Remix + Metamask to deploy contract.
 1. Go to your contract on Etherscan.io and choose **Verify And Publish**
 1. Copy content of `all.sol` in solidity contract code field

--- a/contracts/Chain.sol
+++ b/contracts/Chain.sol
@@ -270,4 +270,14 @@ contract Chain is IChain, RegistrableWithSingleStorage, ReentrancyGuard, Ownable
   returns (uint256) {
     return _storage().initialBlockHeights(_shard);
   }
+
+  // override `SingleStorageStrategy.detachFromStorage`
+  function detachFromStorage(address _newStorageOwner)
+  internal {
+    require(singleStorage.switchOwnerTo(_newStorageOwner), "[detachFromStorage] failed");
+
+    emit LogDetachFromStorage(msg.sender, _newStorageOwner);
+
+    // _suicide(); - do not kill me after unregistering
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "andromeda",
-  "version": "0.2.0",
+  "version": "0.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -282,6 +282,425 @@
         "truffle-hdwallet-provider": "0.0.6",
         "truffle-wallet-provider": "0.0.5",
         "typedarray-to-buffer": "3.1.5"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "10.17.13",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.13.tgz",
+          "integrity": "sha512-pMCcqU2zT4TjqYFrWtYHKal7Sl30Ims6ulZ4UFXxI4xbtQqK/qqKwkDoBFCfooRqqmRu9vY3xaJRwxSh673aYg=="
+        },
+        "aes-js": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
+          "integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0="
+        },
+        "contract-registry": {
+          "version": "git+ssh://git@github.com/luciditytech/contract-registry.git#9c2fe02184f6ce70e836e03aee117ef27dfe7ec4",
+          "from": "git+ssh://git@github.com/luciditytech/contract-registry.git#9c2fe02184f6ce70e836e03aee117ef27dfe7ec4",
+          "requires": {
+            "bignumber.js": "8.1.1",
+            "ethereumjs-util": "6.1.0",
+            "ministro-tool": "0.2.2",
+            "openzeppelin-solidity": "2.1.3",
+            "pify": "4.0.1",
+            "typedarray-to-buffer": "3.1.5",
+            "web3": "1.0.0-beta.47",
+            "web3-eth": "1.0.0-beta.47",
+            "web3-utils": "1.0.0-beta.47"
+          },
+          "dependencies": {
+            "bignumber.js": {
+              "version": "8.1.1",
+              "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-8.1.1.tgz",
+              "integrity": "sha512-QD46ppGintwPGuL1KqmwhR0O+N2cZUg8JG/VzwI2e28sM9TqHjQB10lI4QAaMHVbLzwVLLAwEglpKPViWX+5NQ=="
+            },
+            "openzeppelin-solidity": {
+              "version": "2.1.3",
+              "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-2.1.3.tgz",
+              "integrity": "sha512-Zz595xw6w4ZrNU3JJJTlPd8bHFbHv5OkJlkqsM2i+NBs6CzImoHI3dZ+nmhkfR+p52cGXKmayAGbnfdCum1SMg=="
+            }
+          }
+        },
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "ethereumjs-util": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.1.0.tgz",
+          "integrity": "sha512-URESKMFbDeJxnAxPppnk2fN6Y3BIatn9fwn76Lm8bQlt+s52TpG8dN9M66MLPuRAiAOIqL3dfwqWJf0sd0fL0Q==",
+          "requires": {
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "ethjs-util": "0.1.6",
+            "keccak": "^1.0.2",
+            "rlp": "^2.0.0",
+            "safe-buffer": "^5.1.1",
+            "secp256k1": "^3.0.1"
+          }
+        },
+        "ethers": {
+          "version": "4.0.43",
+          "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.43.tgz",
+          "integrity": "sha512-VjQRVgPrlU12jSMvypdE1yEqYQccdVbH8bbiz67dLF7raHlRV4+zW70GlxHcZYqgsnz0XYWrn6C06gqTQRb5tw==",
+          "requires": {
+            "aes-js": "3.0.0",
+            "bn.js": "^4.4.0",
+            "elliptic": "6.5.2",
+            "hash.js": "1.1.3",
+            "js-sha3": "0.5.7",
+            "scrypt-js": "2.0.4",
+            "setimmediate": "1.0.4",
+            "uuid": "2.0.1",
+            "xmlhttprequest": "1.8.0"
+          },
+          "dependencies": {
+            "elliptic": {
+              "version": "6.5.2",
+              "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
+              "integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
+              "requires": {
+                "bn.js": "^4.4.0",
+                "brorand": "^1.0.1",
+                "hash.js": "^1.0.0",
+                "hmac-drbg": "^1.0.0",
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0",
+                "minimalistic-crypto-utils": "^1.0.0"
+              }
+            }
+          }
+        },
+        "ethjs-util": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.6.tgz",
+          "integrity": "sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==",
+          "requires": {
+            "is-hex-prefixed": "1.0.0",
+            "strip-hex-prefix": "1.0.0"
+          }
+        },
+        "eventemitter3": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.0.tgz",
+          "integrity": "sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA=="
+        },
+        "hash.js": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+          "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "minimalistic-assert": "^1.0.0"
+          }
+        },
+        "js-sha3": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
+          "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
+        },
+        "oboe": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/oboe/-/oboe-2.1.4.tgz",
+          "integrity": "sha1-IMiM2wwVNxuwQRklfU/dNLCqSfY=",
+          "requires": {
+            "http-https": "^1.0.0"
+          }
+        },
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
+        },
+        "scrypt-js": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.4.tgz",
+          "integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw=="
+        },
+        "utf8": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.1.tgz",
+          "integrity": "sha1-LgHbAvfY0JRPdxBPFgnrDDBM92g="
+        },
+        "uuid": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
+        },
+        "web3": {
+          "version": "1.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/web3/-/web3-1.0.0-beta.47.tgz",
+          "integrity": "sha512-jw0wa3VNPKursVLc1LvxRx1e26ebZK4TsPY758q/soYnuTSzkpSRjErESAiLjSrFV0F8Ass6z/6o1SAke0yTtA==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "@types/node": "^10.12.18",
+            "web3-bzz": "1.0.0-beta.47",
+            "web3-core": "1.0.0-beta.47",
+            "web3-core-helpers": "1.0.0-beta.47",
+            "web3-core-method": "1.0.0-beta.47",
+            "web3-eth": "1.0.0-beta.47",
+            "web3-eth-personal": "1.0.0-beta.47",
+            "web3-net": "1.0.0-beta.47",
+            "web3-providers": "1.0.0-beta.47",
+            "web3-shh": "1.0.0-beta.47",
+            "web3-utils": "1.0.0-beta.47"
+          }
+        },
+        "web3-bzz": {
+          "version": "1.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.0.0-beta.47.tgz",
+          "integrity": "sha512-GPMKpt+Hz1GJuUIyWnFDJ+2OOOFkUZxaz8jXGANu+XGL7Aj6QhRTPzOwsDqBgLX2yX3giDR2yUO2CzWWrATeHA==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "@types/node": "^10.12.18",
+            "lodash": "^4.17.11",
+            "swarm-js": "^0.1.39"
+          }
+        },
+        "web3-core": {
+          "version": "1.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.0.0-beta.47.tgz",
+          "integrity": "sha512-/wsYCqbAOHRLdqwN8Pv7fikGRgoOWOSulR0OksRV80V9qfIbItDNJeEdqsUMfybAx4W7xupqyWxrgsRW53ZN+g==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "@types/node": "^10.12.18",
+            "lodash": "^4.17.11",
+            "web3-utils": "1.0.0-beta.47"
+          }
+        },
+        "web3-core-helpers": {
+          "version": "1.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.0.0-beta.47.tgz",
+          "integrity": "sha512-A/Yh1L1h8Yfd0MJaBcrU1XP2xPeXG1Mphq/zkf9fhom4BgkXagrUjEaPCe5iN98Zgdn9w7MQpibyNu0aUAcxNA==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "lodash": "^4.17.11",
+            "web3-eth-iban": "1.0.0-beta.47",
+            "web3-utils": "1.0.0-beta.47"
+          }
+        },
+        "web3-core-method": {
+          "version": "1.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.0.0-beta.47.tgz",
+          "integrity": "sha512-fYov9JMnyhJs+6FBoCbVEKocFGedTueBy4ZdhHywsFyhY2Ch54VEPHNBg1J6PqFF5hHMvv0QBk1d2wEHNcPrXw==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "eventemitter3": "3.1.0",
+            "lodash": "^4.17.11",
+            "web3-core": "1.0.0-beta.47",
+            "web3-core-helpers": "1.0.0-beta.47",
+            "web3-core-promievent": "1.0.0-beta.47",
+            "web3-core-subscriptions": "1.0.0-beta.47",
+            "web3-utils": "1.0.0-beta.47"
+          }
+        },
+        "web3-core-promievent": {
+          "version": "1.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.0.0-beta.47.tgz",
+          "integrity": "sha512-SaJGeoO783mFEhFG9CeokKMpNu9rl9w09fD44SKQIvBh1i6ImIJmxtbwrqNrNSxHzjBguoF1bwRsO8AjtMoB6Q==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "eventemitter3": "^3.1.0"
+          }
+        },
+        "web3-core-subscriptions": {
+          "version": "1.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.0.0-beta.47.tgz",
+          "integrity": "sha512-FUFcuGOvIK52H0hYYutD0iSGMRZt4KWUFe2TiLeLz3+UeGJbSn3bVe1Sm4YpVw5mmQ/0cNb3fXyMphu1iKW6sA==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "eventemitter3": "^3.1.0",
+            "lodash": "^4.17.11",
+            "web3-core-helpers": "1.0.0-beta.47",
+            "web3-utils": "1.0.0-beta.47"
+          }
+        },
+        "web3-eth": {
+          "version": "1.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.0.0-beta.47.tgz",
+          "integrity": "sha512-VpSIrEO2isxjIvAcPCrisS+bweKrwPULm1vwM00yos93REYaUJBAUfrgIM3fc5xmFZjOwyiAc4q6RwtsIlYSQw==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "eth-lib": "0.2.8",
+            "web3-core": "1.0.0-beta.47",
+            "web3-core-helpers": "1.0.0-beta.47",
+            "web3-core-method": "1.0.0-beta.47",
+            "web3-core-subscriptions": "1.0.0-beta.47",
+            "web3-eth-abi": "1.0.0-beta.47",
+            "web3-eth-accounts": "1.0.0-beta.47",
+            "web3-eth-contract": "1.0.0-beta.47",
+            "web3-eth-ens": "1.0.0-beta.47",
+            "web3-eth-iban": "1.0.0-beta.47",
+            "web3-eth-personal": "1.0.0-beta.47",
+            "web3-net": "1.0.0-beta.47",
+            "web3-providers": "1.0.0-beta.47",
+            "web3-utils": "1.0.0-beta.47"
+          }
+        },
+        "web3-eth-abi": {
+          "version": "1.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.0.0-beta.47.tgz",
+          "integrity": "sha512-uYr8OSznOwhbYFg3PxYGum2FjkoZIsssYUyMF/cyvZl5+2+DvlJGCuQ0r9+wi+Z1AomkHxQZ03YBjCJJD1uQPQ==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "ethers": "^4.0.0",
+            "lodash": "^4.17.11",
+            "web3-utils": "1.0.0-beta.47"
+          }
+        },
+        "web3-eth-accounts": {
+          "version": "1.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.0.0-beta.47.tgz",
+          "integrity": "sha512-I7Tk7aKr1driXH7fHYnRGhQLZyi4uQqTpIi33gLbibBoFRN+B6KbQN5/fuPPuJbBbo1yqUI/ox+ID+3idEfWpA==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "crypto-browserify": "3.12.0",
+            "eth-lib": "0.2.8",
+            "lodash": "^4.17.11",
+            "scrypt.js": "0.2.0",
+            "uuid": "3.3.2",
+            "web3-core": "1.0.0-beta.47",
+            "web3-core-helpers": "1.0.0-beta.47",
+            "web3-core-method": "1.0.0-beta.47",
+            "web3-providers": "1.0.0-beta.47",
+            "web3-utils": "1.0.0-beta.47"
+          },
+          "dependencies": {
+            "uuid": {
+              "version": "3.3.2",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+              "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+            }
+          }
+        },
+        "web3-eth-contract": {
+          "version": "1.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.0.0-beta.47.tgz",
+          "integrity": "sha512-n9fShGnBoReei6IafpOrjhA+XGgjoCxIRHHanpe7MX6YQm/5ldDQMCpp7qCk4+XrgN5dk09cL/L1Tc1z3zHEjw==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "lodash": "^4.17.11",
+            "web3-core": "1.0.0-beta.47",
+            "web3-core-helpers": "1.0.0-beta.47",
+            "web3-core-method": "1.0.0-beta.47",
+            "web3-core-promievent": "1.0.0-beta.47",
+            "web3-core-subscriptions": "1.0.0-beta.47",
+            "web3-eth-abi": "1.0.0-beta.47",
+            "web3-eth-accounts": "1.0.0-beta.47",
+            "web3-providers": "1.0.0-beta.47",
+            "web3-utils": "1.0.0-beta.47"
+          }
+        },
+        "web3-eth-ens": {
+          "version": "1.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.0.0-beta.47.tgz",
+          "integrity": "sha512-gj6z6NCnew8VHIlDDG9eP1/WF5m1ri72NhYCIzsZ82kW1Bw9LBs0xw/zhimaRgAxnS7qcqHv8WJLa4w0A3QJ0Q==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "eth-ens-namehash": "2.0.8",
+            "lodash": "^4.17.11",
+            "web3-core": "1.0.0-beta.47",
+            "web3-core-helpers": "1.0.0-beta.47",
+            "web3-core-method": "1.0.0-beta.47",
+            "web3-core-promievent": "1.0.0-beta.47",
+            "web3-eth-abi": "1.0.0-beta.47",
+            "web3-eth-contract": "1.0.0-beta.47",
+            "web3-net": "1.0.0-beta.47",
+            "web3-providers": "1.0.0-beta.47",
+            "web3-utils": "1.0.0-beta.47"
+          }
+        },
+        "web3-eth-iban": {
+          "version": "1.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.0.0-beta.47.tgz",
+          "integrity": "sha512-/d0x+GG8BTyr9UovNLB6Rt5I6iYyn4Xj1/lGb2gHTffaFWD4StVevjeNEI8zTWrf2bEsb0xP6CjASQzNrQQVFQ==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "bn.js": "4.11.8",
+            "web3-utils": "1.0.0-beta.47"
+          }
+        },
+        "web3-eth-personal": {
+          "version": "1.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.0.0-beta.47.tgz",
+          "integrity": "sha512-0WzFdM2VCjIbbrNJu+VcNgbgsoq9RoKTUaAdLc7NjWv9szOqYgPphSjaThJ9v/EciLcIR/KFPN8DBYZ3gh4mWA==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "web3-core": "1.0.0-beta.47",
+            "web3-core-helpers": "1.0.0-beta.47",
+            "web3-core-method": "1.0.0-beta.47",
+            "web3-net": "1.0.0-beta.47",
+            "web3-providers": "1.0.0-beta.47",
+            "web3-utils": "1.0.0-beta.47"
+          }
+        },
+        "web3-net": {
+          "version": "1.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.0.0-beta.47.tgz",
+          "integrity": "sha512-3ywuCATkk5z9M4bv8/1TjgVDvR2LyuDqWhM39O1vlTor33cCb1SP1clmbS0j2BJe89QN+haxijTcSRQEsC8l0g==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "lodash": "^4.17.11",
+            "web3-core": "1.0.0-beta.47",
+            "web3-core-helpers": "1.0.0-beta.47",
+            "web3-core-method": "1.0.0-beta.47",
+            "web3-providers": "1.0.0-beta.47",
+            "web3-utils": "1.0.0-beta.47"
+          }
+        },
+        "web3-providers": {
+          "version": "1.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/web3-providers/-/web3-providers-1.0.0-beta.47.tgz",
+          "integrity": "sha512-mgho0luErniheu6XHJr/kaSHWSDd7RwvGZUFbSX55j9U6UO5Qc4o/l8kPVafcab694XoF7HHFfAZ1KGKnnIbFw==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "@types/node": "^10.12.18",
+            "eventemitter3": "3.1.0",
+            "lodash": "^4.17.11",
+            "oboe": "2.1.4",
+            "url-parse": "1.4.4",
+            "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
+            "xhr2-cookies": "1.1.0"
+          }
+        },
+        "web3-shh": {
+          "version": "1.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.0.0-beta.47.tgz",
+          "integrity": "sha512-1ru6eruSN0zYV3S8cRnBb1PwciEvKbdhkcPStykYTvNiJ6juVS5E/Mbw7zscDjoaRwe/61w3OkE48utVjafNFw==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "web3-core": "1.0.0-beta.47",
+            "web3-core-helpers": "1.0.0-beta.47",
+            "web3-core-method": "1.0.0-beta.47",
+            "web3-core-subscriptions": "1.0.0-beta.47",
+            "web3-net": "1.0.0-beta.47",
+            "web3-providers": "1.0.0-beta.47",
+            "web3-utils": "1.0.0-beta.47"
+          }
+        },
+        "web3-utils": {
+          "version": "1.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.47.tgz",
+          "integrity": "sha512-Mn/n6qanKIi8uRGTYlqD55ZSRZjG8CsHE9CA6i8vLTn6PdRcKReJW1D4YNYTVAnNkyohkO4f4FSRtKE0DVa50w==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "@types/bn.js": "^4.11.4",
+            "@types/node": "^10.12.18",
+            "bn.js": "4.11.8",
+            "eth-lib": "0.2.8",
+            "ethjs-unit": "^0.1.6",
+            "lodash": "^4.17.11",
+            "number-to-bn": "1.7.0",
+            "randomhex": "0.1.5",
+            "utf8": "2.1.1"
+          }
+        }
       }
     },
     "ansi-escapes": {
@@ -1784,8 +2203,8 @@
       "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
     },
     "contract-registry": {
-      "version": "git+ssh://git@github.com/luciditytech/contract-registry.git#9c2fe02184f6ce70e836e03aee117ef27dfe7ec4",
-      "from": "git+ssh://git@github.com/luciditytech/contract-registry.git#9c2fe02184f6ce70e836e03aee117ef27dfe7ec4",
+      "version": "git+ssh://git@github.com/luciditytech/contract-registry.git#4eaa0dd6d9c2d14d3bebbee40a546f1dda8eaba2",
+      "from": "git+ssh://git@github.com/luciditytech/contract-registry.git#4eaa0dd6d9c2d14d3bebbee40a546f1dda8eaba2",
       "requires": {
         "bignumber.js": "8.1.1",
         "ethereumjs-util": "6.1.0",
@@ -1799,9 +2218,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.14.1",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.1.tgz",
-          "integrity": "sha512-Rymt08vh1GaW4vYB6QP61/5m/CFLGnFZP++bJpWbiNxceNa6RBipDmb413jvtSf/R1gg5a/jQVl2jY4XVRscEA=="
+          "version": "10.17.13",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.13.tgz",
+          "integrity": "sha512-pMCcqU2zT4TjqYFrWtYHKal7Sl30Ims6ulZ4UFXxI4xbtQqK/qqKwkDoBFCfooRqqmRu9vY3xaJRwxSh673aYg=="
         },
         "aes-js": {
           "version": "3.0.0",
@@ -1838,14 +2257,13 @@
           }
         },
         "ethers": {
-          "version": "4.0.27",
-          "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.27.tgz",
-          "integrity": "sha512-+DXZLP/tyFnXWxqr2fXLT67KlGUfLuvDkHSOtSC9TUVG9OIj6yrG5JPeXRMYo15xkOYwnjgdMKrXp5V94rtjJA==",
+          "version": "4.0.43",
+          "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.43.tgz",
+          "integrity": "sha512-VjQRVgPrlU12jSMvypdE1yEqYQccdVbH8bbiz67dLF7raHlRV4+zW70GlxHcZYqgsnz0XYWrn6C06gqTQRb5tw==",
           "requires": {
-            "@types/node": "^10.3.2",
             "aes-js": "3.0.0",
             "bn.js": "^4.4.0",
-            "elliptic": "6.3.3",
+            "elliptic": "6.5.2",
             "hash.js": "1.1.3",
             "js-sha3": "0.5.7",
             "scrypt-js": "2.0.4",
@@ -1855,14 +2273,17 @@
           },
           "dependencies": {
             "elliptic": {
-              "version": "6.3.3",
-              "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.3.tgz",
-              "integrity": "sha1-VILZZG1UvLif19mU/J4ulWiHbj8=",
+              "version": "6.5.2",
+              "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
+              "integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
               "requires": {
                 "bn.js": "^4.4.0",
                 "brorand": "^1.0.1",
                 "hash.js": "^1.0.0",
-                "inherits": "^2.0.1"
+                "hmac-drbg": "^1.0.0",
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0",
+                "minimalistic-crypto-utils": "^1.0.0"
               }
             }
           }
@@ -2668,6 +3089,16 @@
         "truffle-hdwallet-provider": "1.0.3"
       },
       "dependencies": {
+        "@types/node": {
+          "version": "10.17.13",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.13.tgz",
+          "integrity": "sha512-pMCcqU2zT4TjqYFrWtYHKal7Sl30Ims6ulZ4UFXxI4xbtQqK/qqKwkDoBFCfooRqqmRu9vY3xaJRwxSh673aYg=="
+        },
+        "aes-js": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
+          "integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0="
+        },
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
@@ -2701,6 +3132,66 @@
             "wrap-ansi": "^2.0.0"
           }
         },
+        "contract-registry": {
+          "version": "git+ssh://git@github.com/luciditytech/contract-registry.git#9c2fe02184f6ce70e836e03aee117ef27dfe7ec4",
+          "from": "git+ssh://git@github.com/luciditytech/contract-registry.git#9c2fe02184f6ce70e836e03aee117ef27dfe7ec4",
+          "requires": {
+            "bignumber.js": "8.1.1",
+            "ethereumjs-util": "6.1.0",
+            "ministro-tool": "0.2.2",
+            "openzeppelin-solidity": "2.1.3",
+            "pify": "4.0.1",
+            "typedarray-to-buffer": "3.1.5",
+            "web3": "1.0.0-beta.47",
+            "web3-eth": "1.0.0-beta.47",
+            "web3-utils": "1.0.0-beta.47"
+          },
+          "dependencies": {
+            "bignumber.js": {
+              "version": "8.1.1",
+              "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-8.1.1.tgz",
+              "integrity": "sha512-QD46ppGintwPGuL1KqmwhR0O+N2cZUg8JG/VzwI2e28sM9TqHjQB10lI4QAaMHVbLzwVLLAwEglpKPViWX+5NQ=="
+            },
+            "ethereumjs-util": {
+              "version": "6.1.0",
+              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.1.0.tgz",
+              "integrity": "sha512-URESKMFbDeJxnAxPppnk2fN6Y3BIatn9fwn76Lm8bQlt+s52TpG8dN9M66MLPuRAiAOIqL3dfwqWJf0sd0fL0Q==",
+              "requires": {
+                "bn.js": "^4.11.0",
+                "create-hash": "^1.1.2",
+                "ethjs-util": "0.1.6",
+                "keccak": "^1.0.2",
+                "rlp": "^2.0.0",
+                "safe-buffer": "^5.1.1",
+                "secp256k1": "^3.0.1"
+              }
+            },
+            "ethjs-util": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.6.tgz",
+              "integrity": "sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==",
+              "requires": {
+                "is-hex-prefixed": "1.0.0",
+                "strip-hex-prefix": "1.0.0"
+              }
+            },
+            "openzeppelin-solidity": {
+              "version": "2.1.3",
+              "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-2.1.3.tgz",
+              "integrity": "sha512-Zz595xw6w4ZrNU3JJJTlPd8bHFbHv5OkJlkqsM2i+NBs6CzImoHI3dZ+nmhkfR+p52cGXKmayAGbnfdCum1SMg=="
+            }
+          }
+        },
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
         "ethereumjs-abi": {
           "version": "0.6.6",
           "resolved": "https://registry.npmjs.org/ethereumjs-abi/-/ethereumjs-abi-0.6.6.tgz",
@@ -2723,6 +3214,43 @@
             "safe-buffer": "^5.1.1",
             "secp256k1": "^3.0.1"
           }
+        },
+        "ethers": {
+          "version": "4.0.43",
+          "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.43.tgz",
+          "integrity": "sha512-VjQRVgPrlU12jSMvypdE1yEqYQccdVbH8bbiz67dLF7raHlRV4+zW70GlxHcZYqgsnz0XYWrn6C06gqTQRb5tw==",
+          "requires": {
+            "aes-js": "3.0.0",
+            "bn.js": "^4.4.0",
+            "elliptic": "6.5.2",
+            "hash.js": "1.1.3",
+            "js-sha3": "0.5.7",
+            "scrypt-js": "2.0.4",
+            "setimmediate": "1.0.4",
+            "uuid": "2.0.1",
+            "xmlhttprequest": "1.8.0"
+          },
+          "dependencies": {
+            "elliptic": {
+              "version": "6.5.2",
+              "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
+              "integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
+              "requires": {
+                "bn.js": "^4.4.0",
+                "brorand": "^1.0.1",
+                "hash.js": "^1.0.0",
+                "hmac-drbg": "^1.0.0",
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0",
+                "minimalistic-crypto-utils": "^1.0.0"
+              }
+            }
+          }
+        },
+        "eventemitter3": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.0.tgz",
+          "integrity": "sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA=="
         },
         "find-up": {
           "version": "2.1.0",
@@ -3057,15 +3585,37 @@
             }
           }
         },
+        "hash.js": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+          "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "minimalistic-assert": "^1.0.0"
+          }
+        },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
         },
+        "js-sha3": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
+          "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
+        },
         "nan": {
           "version": "2.13.1",
           "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.1.tgz",
           "integrity": "sha512-I6YB/YEuDeUZMmhscXKxGgZlFnhsn5y0hgOZBadkzfTRrZBtJDZeg6eQf7PYMIEclwmorTKK8GztsyOUSVBREA=="
+        },
+        "oboe": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/oboe/-/oboe-2.1.4.tgz",
+          "integrity": "sha1-IMiM2wwVNxuwQRklfU/dNLCqSfY=",
+          "requires": {
+            "http-https": "^1.0.0"
+          }
         },
         "os-locale": {
           "version": "2.1.0",
@@ -3077,10 +3627,20 @@
             "mem": "^1.1.0"
           }
         },
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
+        },
         "require-from-string": {
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
           "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
+        },
+        "scrypt-js": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.4.tgz",
+          "integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw=="
         },
         "semver": {
           "version": "5.6.0",
@@ -3136,6 +3696,296 @@
             "any-promise": "^1.3.0",
             "bindings": "^1.3.1",
             "websocket": "^1.0.28"
+          }
+        },
+        "utf8": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.1.tgz",
+          "integrity": "sha1-LgHbAvfY0JRPdxBPFgnrDDBM92g="
+        },
+        "uuid": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
+        },
+        "web3": {
+          "version": "1.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/web3/-/web3-1.0.0-beta.47.tgz",
+          "integrity": "sha512-jw0wa3VNPKursVLc1LvxRx1e26ebZK4TsPY758q/soYnuTSzkpSRjErESAiLjSrFV0F8Ass6z/6o1SAke0yTtA==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "@types/node": "^10.12.18",
+            "web3-bzz": "1.0.0-beta.47",
+            "web3-core": "1.0.0-beta.47",
+            "web3-core-helpers": "1.0.0-beta.47",
+            "web3-core-method": "1.0.0-beta.47",
+            "web3-eth": "1.0.0-beta.47",
+            "web3-eth-personal": "1.0.0-beta.47",
+            "web3-net": "1.0.0-beta.47",
+            "web3-providers": "1.0.0-beta.47",
+            "web3-shh": "1.0.0-beta.47",
+            "web3-utils": "1.0.0-beta.47"
+          }
+        },
+        "web3-bzz": {
+          "version": "1.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.0.0-beta.47.tgz",
+          "integrity": "sha512-GPMKpt+Hz1GJuUIyWnFDJ+2OOOFkUZxaz8jXGANu+XGL7Aj6QhRTPzOwsDqBgLX2yX3giDR2yUO2CzWWrATeHA==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "@types/node": "^10.12.18",
+            "lodash": "^4.17.11",
+            "swarm-js": "^0.1.39"
+          }
+        },
+        "web3-core": {
+          "version": "1.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.0.0-beta.47.tgz",
+          "integrity": "sha512-/wsYCqbAOHRLdqwN8Pv7fikGRgoOWOSulR0OksRV80V9qfIbItDNJeEdqsUMfybAx4W7xupqyWxrgsRW53ZN+g==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "@types/node": "^10.12.18",
+            "lodash": "^4.17.11",
+            "web3-utils": "1.0.0-beta.47"
+          }
+        },
+        "web3-core-helpers": {
+          "version": "1.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.0.0-beta.47.tgz",
+          "integrity": "sha512-A/Yh1L1h8Yfd0MJaBcrU1XP2xPeXG1Mphq/zkf9fhom4BgkXagrUjEaPCe5iN98Zgdn9w7MQpibyNu0aUAcxNA==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "lodash": "^4.17.11",
+            "web3-eth-iban": "1.0.0-beta.47",
+            "web3-utils": "1.0.0-beta.47"
+          }
+        },
+        "web3-core-method": {
+          "version": "1.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.0.0-beta.47.tgz",
+          "integrity": "sha512-fYov9JMnyhJs+6FBoCbVEKocFGedTueBy4ZdhHywsFyhY2Ch54VEPHNBg1J6PqFF5hHMvv0QBk1d2wEHNcPrXw==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "eventemitter3": "3.1.0",
+            "lodash": "^4.17.11",
+            "web3-core": "1.0.0-beta.47",
+            "web3-core-helpers": "1.0.0-beta.47",
+            "web3-core-promievent": "1.0.0-beta.47",
+            "web3-core-subscriptions": "1.0.0-beta.47",
+            "web3-utils": "1.0.0-beta.47"
+          }
+        },
+        "web3-core-promievent": {
+          "version": "1.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.0.0-beta.47.tgz",
+          "integrity": "sha512-SaJGeoO783mFEhFG9CeokKMpNu9rl9w09fD44SKQIvBh1i6ImIJmxtbwrqNrNSxHzjBguoF1bwRsO8AjtMoB6Q==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "eventemitter3": "^3.1.0"
+          }
+        },
+        "web3-core-subscriptions": {
+          "version": "1.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.0.0-beta.47.tgz",
+          "integrity": "sha512-FUFcuGOvIK52H0hYYutD0iSGMRZt4KWUFe2TiLeLz3+UeGJbSn3bVe1Sm4YpVw5mmQ/0cNb3fXyMphu1iKW6sA==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "eventemitter3": "^3.1.0",
+            "lodash": "^4.17.11",
+            "web3-core-helpers": "1.0.0-beta.47",
+            "web3-utils": "1.0.0-beta.47"
+          }
+        },
+        "web3-eth": {
+          "version": "1.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.0.0-beta.47.tgz",
+          "integrity": "sha512-VpSIrEO2isxjIvAcPCrisS+bweKrwPULm1vwM00yos93REYaUJBAUfrgIM3fc5xmFZjOwyiAc4q6RwtsIlYSQw==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "eth-lib": "0.2.8",
+            "web3-core": "1.0.0-beta.47",
+            "web3-core-helpers": "1.0.0-beta.47",
+            "web3-core-method": "1.0.0-beta.47",
+            "web3-core-subscriptions": "1.0.0-beta.47",
+            "web3-eth-abi": "1.0.0-beta.47",
+            "web3-eth-accounts": "1.0.0-beta.47",
+            "web3-eth-contract": "1.0.0-beta.47",
+            "web3-eth-ens": "1.0.0-beta.47",
+            "web3-eth-iban": "1.0.0-beta.47",
+            "web3-eth-personal": "1.0.0-beta.47",
+            "web3-net": "1.0.0-beta.47",
+            "web3-providers": "1.0.0-beta.47",
+            "web3-utils": "1.0.0-beta.47"
+          }
+        },
+        "web3-eth-abi": {
+          "version": "1.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.0.0-beta.47.tgz",
+          "integrity": "sha512-uYr8OSznOwhbYFg3PxYGum2FjkoZIsssYUyMF/cyvZl5+2+DvlJGCuQ0r9+wi+Z1AomkHxQZ03YBjCJJD1uQPQ==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "ethers": "^4.0.0",
+            "lodash": "^4.17.11",
+            "web3-utils": "1.0.0-beta.47"
+          }
+        },
+        "web3-eth-accounts": {
+          "version": "1.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.0.0-beta.47.tgz",
+          "integrity": "sha512-I7Tk7aKr1driXH7fHYnRGhQLZyi4uQqTpIi33gLbibBoFRN+B6KbQN5/fuPPuJbBbo1yqUI/ox+ID+3idEfWpA==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "crypto-browserify": "3.12.0",
+            "eth-lib": "0.2.8",
+            "lodash": "^4.17.11",
+            "scrypt.js": "0.2.0",
+            "uuid": "3.3.2",
+            "web3-core": "1.0.0-beta.47",
+            "web3-core-helpers": "1.0.0-beta.47",
+            "web3-core-method": "1.0.0-beta.47",
+            "web3-providers": "1.0.0-beta.47",
+            "web3-utils": "1.0.0-beta.47"
+          },
+          "dependencies": {
+            "uuid": {
+              "version": "3.3.2",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+              "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+            }
+          }
+        },
+        "web3-eth-contract": {
+          "version": "1.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.0.0-beta.47.tgz",
+          "integrity": "sha512-n9fShGnBoReei6IafpOrjhA+XGgjoCxIRHHanpe7MX6YQm/5ldDQMCpp7qCk4+XrgN5dk09cL/L1Tc1z3zHEjw==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "lodash": "^4.17.11",
+            "web3-core": "1.0.0-beta.47",
+            "web3-core-helpers": "1.0.0-beta.47",
+            "web3-core-method": "1.0.0-beta.47",
+            "web3-core-promievent": "1.0.0-beta.47",
+            "web3-core-subscriptions": "1.0.0-beta.47",
+            "web3-eth-abi": "1.0.0-beta.47",
+            "web3-eth-accounts": "1.0.0-beta.47",
+            "web3-providers": "1.0.0-beta.47",
+            "web3-utils": "1.0.0-beta.47"
+          }
+        },
+        "web3-eth-ens": {
+          "version": "1.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.0.0-beta.47.tgz",
+          "integrity": "sha512-gj6z6NCnew8VHIlDDG9eP1/WF5m1ri72NhYCIzsZ82kW1Bw9LBs0xw/zhimaRgAxnS7qcqHv8WJLa4w0A3QJ0Q==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "eth-ens-namehash": "2.0.8",
+            "lodash": "^4.17.11",
+            "web3-core": "1.0.0-beta.47",
+            "web3-core-helpers": "1.0.0-beta.47",
+            "web3-core-method": "1.0.0-beta.47",
+            "web3-core-promievent": "1.0.0-beta.47",
+            "web3-eth-abi": "1.0.0-beta.47",
+            "web3-eth-contract": "1.0.0-beta.47",
+            "web3-net": "1.0.0-beta.47",
+            "web3-providers": "1.0.0-beta.47",
+            "web3-utils": "1.0.0-beta.47"
+          }
+        },
+        "web3-eth-iban": {
+          "version": "1.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.0.0-beta.47.tgz",
+          "integrity": "sha512-/d0x+GG8BTyr9UovNLB6Rt5I6iYyn4Xj1/lGb2gHTffaFWD4StVevjeNEI8zTWrf2bEsb0xP6CjASQzNrQQVFQ==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "bn.js": "4.11.8",
+            "web3-utils": "1.0.0-beta.47"
+          }
+        },
+        "web3-eth-personal": {
+          "version": "1.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.0.0-beta.47.tgz",
+          "integrity": "sha512-0WzFdM2VCjIbbrNJu+VcNgbgsoq9RoKTUaAdLc7NjWv9szOqYgPphSjaThJ9v/EciLcIR/KFPN8DBYZ3gh4mWA==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "web3-core": "1.0.0-beta.47",
+            "web3-core-helpers": "1.0.0-beta.47",
+            "web3-core-method": "1.0.0-beta.47",
+            "web3-net": "1.0.0-beta.47",
+            "web3-providers": "1.0.0-beta.47",
+            "web3-utils": "1.0.0-beta.47"
+          }
+        },
+        "web3-net": {
+          "version": "1.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.0.0-beta.47.tgz",
+          "integrity": "sha512-3ywuCATkk5z9M4bv8/1TjgVDvR2LyuDqWhM39O1vlTor33cCb1SP1clmbS0j2BJe89QN+haxijTcSRQEsC8l0g==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "lodash": "^4.17.11",
+            "web3-core": "1.0.0-beta.47",
+            "web3-core-helpers": "1.0.0-beta.47",
+            "web3-core-method": "1.0.0-beta.47",
+            "web3-providers": "1.0.0-beta.47",
+            "web3-utils": "1.0.0-beta.47"
+          }
+        },
+        "web3-providers": {
+          "version": "1.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/web3-providers/-/web3-providers-1.0.0-beta.47.tgz",
+          "integrity": "sha512-mgho0luErniheu6XHJr/kaSHWSDd7RwvGZUFbSX55j9U6UO5Qc4o/l8kPVafcab694XoF7HHFfAZ1KGKnnIbFw==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "@types/node": "^10.12.18",
+            "eventemitter3": "3.1.0",
+            "lodash": "^4.17.11",
+            "oboe": "2.1.4",
+            "url-parse": "1.4.4",
+            "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
+            "xhr2-cookies": "1.1.0"
+          },
+          "dependencies": {
+            "websocket": {
+              "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
+              "from": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible",
+              "requires": {
+                "debug": "^2.2.0",
+                "nan": "^2.3.3",
+                "typedarray-to-buffer": "^3.1.2",
+                "yaeti": "^0.0.6"
+              }
+            }
+          }
+        },
+        "web3-shh": {
+          "version": "1.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.0.0-beta.47.tgz",
+          "integrity": "sha512-1ru6eruSN0zYV3S8cRnBb1PwciEvKbdhkcPStykYTvNiJ6juVS5E/Mbw7zscDjoaRwe/61w3OkE48utVjafNFw==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "web3-core": "1.0.0-beta.47",
+            "web3-core-helpers": "1.0.0-beta.47",
+            "web3-core-method": "1.0.0-beta.47",
+            "web3-core-subscriptions": "1.0.0-beta.47",
+            "web3-net": "1.0.0-beta.47",
+            "web3-providers": "1.0.0-beta.47",
+            "web3-utils": "1.0.0-beta.47"
+          }
+        },
+        "web3-utils": {
+          "version": "1.0.0-beta.47",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.47.tgz",
+          "integrity": "sha512-Mn/n6qanKIi8uRGTYlqD55ZSRZjG8CsHE9CA6i8vLTn6PdRcKReJW1D4YNYTVAnNkyohkO4f4FSRtKE0DVa50w==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "@types/bn.js": "^4.11.4",
+            "@types/node": "^10.12.18",
+            "bn.js": "4.11.8",
+            "eth-lib": "0.2.8",
+            "ethjs-unit": "^0.1.6",
+            "lodash": "^4.17.11",
+            "number-to-bn": "1.7.0",
+            "randomhex": "0.1.5",
+            "utf8": "2.1.1"
           }
         },
         "websocket": {
@@ -3839,12 +4689,69 @@
         "ethereumjs-util": "^5.1.1"
       },
       "dependencies": {
+        "bindings": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+          "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+          "requires": {
+            "file-uri-to-path": "1.0.0"
+          }
+        },
         "ethereumjs-abi": {
           "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#d84a96796079c8595a0c78accd1e7709f2277215",
           "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
           "requires": {
             "bn.js": "^4.11.8",
             "ethereumjs-util": "^6.0.0"
+          },
+          "dependencies": {
+            "ethereumjs-util": {
+              "version": "6.2.0",
+              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.0.tgz",
+              "integrity": "sha512-vb0XN9J2QGdZGIEKG2vXM+kUdEivUfU6Wmi5y0cg+LRhDYKnXIZ/Lz7XjFbHRR9VIKq2lVGLzGBkA++y2nOdOQ==",
+              "requires": {
+                "@types/bn.js": "^4.11.3",
+                "bn.js": "^4.11.0",
+                "create-hash": "^1.1.2",
+                "ethjs-util": "0.1.6",
+                "keccak": "^2.0.0",
+                "rlp": "^2.2.3",
+                "secp256k1": "^3.0.1"
+              }
+            },
+            "ethjs-util": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.6.tgz",
+              "integrity": "sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==",
+              "requires": {
+                "is-hex-prefixed": "1.0.0",
+                "strip-hex-prefix": "1.0.0"
+              }
+            },
+            "keccak": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/keccak/-/keccak-2.1.0.tgz",
+              "integrity": "sha512-m1wbJRTo+gWbctZWay9i26v5fFnYkOn7D5PCxJ3fZUGUEb49dE1Pm4BREUYCt/aoO6di7jeoGmhvqN9Nzylm3Q==",
+              "requires": {
+                "bindings": "^1.5.0",
+                "inherits": "^2.0.4",
+                "nan": "^2.14.0",
+                "safe-buffer": "^5.2.0"
+              }
+            },
+            "rlp": {
+              "version": "2.2.4",
+              "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.4.tgz",
+              "integrity": "sha512-fdq2yYCWpAQBhwkZv+Z8o/Z4sPmYm1CUq6P7n6lVTOdb949CnqA0sndXal5C1NleSVSZm6q5F3iEbauyVln/iw==",
+              "requires": {
+                "bn.js": "^4.11.1"
+              }
+            },
+            "safe-buffer": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+              "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+            }
           }
         },
         "ethereumjs-util": {
@@ -3860,6 +4767,16 @@
             "safe-buffer": "^5.1.1",
             "secp256k1": "^3.0.1"
           }
+        },
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        },
+        "nan": {
+          "version": "2.14.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+          "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
         }
       }
     },
@@ -9299,6 +10216,289 @@
           "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-8.1.1.tgz",
           "integrity": "sha512-QD46ppGintwPGuL1KqmwhR0O+N2cZUg8JG/VzwI2e28sM9TqHjQB10lI4QAaMHVbLzwVLLAwEglpKPViWX+5NQ=="
         },
+        "contract-registry": {
+          "version": "git+ssh://git@github.com/luciditytech/contract-registry.git#9c2fe02184f6ce70e836e03aee117ef27dfe7ec4",
+          "from": "git+ssh://git@github.com/luciditytech/contract-registry.git#9c2fe02184f6ce70e836e03aee117ef27dfe7ec4",
+          "requires": {
+            "bignumber.js": "8.1.1",
+            "ethereumjs-util": "6.1.0",
+            "ministro-tool": "0.2.2",
+            "openzeppelin-solidity": "2.1.3",
+            "pify": "4.0.1",
+            "typedarray-to-buffer": "3.1.5",
+            "web3": "1.0.0-beta.47",
+            "web3-eth": "1.0.0-beta.47",
+            "web3-utils": "1.0.0-beta.47"
+          },
+          "dependencies": {
+            "uuid": {
+              "version": "3.3.2",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+              "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+            },
+            "web3": {
+              "version": "1.0.0-beta.47",
+              "resolved": "https://registry.npmjs.org/web3/-/web3-1.0.0-beta.47.tgz",
+              "integrity": "sha512-jw0wa3VNPKursVLc1LvxRx1e26ebZK4TsPY758q/soYnuTSzkpSRjErESAiLjSrFV0F8Ass6z/6o1SAke0yTtA==",
+              "requires": {
+                "@babel/runtime": "^7.3.1",
+                "@types/node": "^10.12.18",
+                "web3-bzz": "1.0.0-beta.47",
+                "web3-core": "1.0.0-beta.47",
+                "web3-core-helpers": "1.0.0-beta.47",
+                "web3-core-method": "1.0.0-beta.47",
+                "web3-eth": "1.0.0-beta.47",
+                "web3-eth-personal": "1.0.0-beta.47",
+                "web3-net": "1.0.0-beta.47",
+                "web3-providers": "1.0.0-beta.47",
+                "web3-shh": "1.0.0-beta.47",
+                "web3-utils": "1.0.0-beta.47"
+              }
+            },
+            "web3-bzz": {
+              "version": "1.0.0-beta.47",
+              "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.0.0-beta.47.tgz",
+              "integrity": "sha512-GPMKpt+Hz1GJuUIyWnFDJ+2OOOFkUZxaz8jXGANu+XGL7Aj6QhRTPzOwsDqBgLX2yX3giDR2yUO2CzWWrATeHA==",
+              "requires": {
+                "@babel/runtime": "^7.3.1",
+                "@types/node": "^10.12.18",
+                "lodash": "^4.17.11",
+                "swarm-js": "^0.1.39"
+              }
+            },
+            "web3-core": {
+              "version": "1.0.0-beta.47",
+              "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.0.0-beta.47.tgz",
+              "integrity": "sha512-/wsYCqbAOHRLdqwN8Pv7fikGRgoOWOSulR0OksRV80V9qfIbItDNJeEdqsUMfybAx4W7xupqyWxrgsRW53ZN+g==",
+              "requires": {
+                "@babel/runtime": "^7.3.1",
+                "@types/node": "^10.12.18",
+                "lodash": "^4.17.11",
+                "web3-utils": "1.0.0-beta.47"
+              }
+            },
+            "web3-core-helpers": {
+              "version": "1.0.0-beta.47",
+              "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.0.0-beta.47.tgz",
+              "integrity": "sha512-A/Yh1L1h8Yfd0MJaBcrU1XP2xPeXG1Mphq/zkf9fhom4BgkXagrUjEaPCe5iN98Zgdn9w7MQpibyNu0aUAcxNA==",
+              "requires": {
+                "@babel/runtime": "^7.3.1",
+                "lodash": "^4.17.11",
+                "web3-eth-iban": "1.0.0-beta.47",
+                "web3-utils": "1.0.0-beta.47"
+              }
+            },
+            "web3-core-method": {
+              "version": "1.0.0-beta.47",
+              "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.0.0-beta.47.tgz",
+              "integrity": "sha512-fYov9JMnyhJs+6FBoCbVEKocFGedTueBy4ZdhHywsFyhY2Ch54VEPHNBg1J6PqFF5hHMvv0QBk1d2wEHNcPrXw==",
+              "requires": {
+                "@babel/runtime": "^7.3.1",
+                "eventemitter3": "3.1.0",
+                "lodash": "^4.17.11",
+                "web3-core": "1.0.0-beta.47",
+                "web3-core-helpers": "1.0.0-beta.47",
+                "web3-core-promievent": "1.0.0-beta.47",
+                "web3-core-subscriptions": "1.0.0-beta.47",
+                "web3-utils": "1.0.0-beta.47"
+              }
+            },
+            "web3-core-promievent": {
+              "version": "1.0.0-beta.47",
+              "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.0.0-beta.47.tgz",
+              "integrity": "sha512-SaJGeoO783mFEhFG9CeokKMpNu9rl9w09fD44SKQIvBh1i6ImIJmxtbwrqNrNSxHzjBguoF1bwRsO8AjtMoB6Q==",
+              "requires": {
+                "@babel/runtime": "^7.3.1",
+                "eventemitter3": "^3.1.0"
+              }
+            },
+            "web3-core-subscriptions": {
+              "version": "1.0.0-beta.47",
+              "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.0.0-beta.47.tgz",
+              "integrity": "sha512-FUFcuGOvIK52H0hYYutD0iSGMRZt4KWUFe2TiLeLz3+UeGJbSn3bVe1Sm4YpVw5mmQ/0cNb3fXyMphu1iKW6sA==",
+              "requires": {
+                "@babel/runtime": "^7.3.1",
+                "eventemitter3": "^3.1.0",
+                "lodash": "^4.17.11",
+                "web3-core-helpers": "1.0.0-beta.47",
+                "web3-utils": "1.0.0-beta.47"
+              }
+            },
+            "web3-eth": {
+              "version": "1.0.0-beta.47",
+              "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.0.0-beta.47.tgz",
+              "integrity": "sha512-VpSIrEO2isxjIvAcPCrisS+bweKrwPULm1vwM00yos93REYaUJBAUfrgIM3fc5xmFZjOwyiAc4q6RwtsIlYSQw==",
+              "requires": {
+                "@babel/runtime": "^7.3.1",
+                "eth-lib": "0.2.8",
+                "web3-core": "1.0.0-beta.47",
+                "web3-core-helpers": "1.0.0-beta.47",
+                "web3-core-method": "1.0.0-beta.47",
+                "web3-core-subscriptions": "1.0.0-beta.47",
+                "web3-eth-abi": "1.0.0-beta.47",
+                "web3-eth-accounts": "1.0.0-beta.47",
+                "web3-eth-contract": "1.0.0-beta.47",
+                "web3-eth-ens": "1.0.0-beta.47",
+                "web3-eth-iban": "1.0.0-beta.47",
+                "web3-eth-personal": "1.0.0-beta.47",
+                "web3-net": "1.0.0-beta.47",
+                "web3-providers": "1.0.0-beta.47",
+                "web3-utils": "1.0.0-beta.47"
+              }
+            },
+            "web3-eth-abi": {
+              "version": "1.0.0-beta.47",
+              "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.0.0-beta.47.tgz",
+              "integrity": "sha512-uYr8OSznOwhbYFg3PxYGum2FjkoZIsssYUyMF/cyvZl5+2+DvlJGCuQ0r9+wi+Z1AomkHxQZ03YBjCJJD1uQPQ==",
+              "requires": {
+                "@babel/runtime": "^7.3.1",
+                "ethers": "^4.0.0",
+                "lodash": "^4.17.11",
+                "web3-utils": "1.0.0-beta.47"
+              }
+            },
+            "web3-eth-accounts": {
+              "version": "1.0.0-beta.47",
+              "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.0.0-beta.47.tgz",
+              "integrity": "sha512-I7Tk7aKr1driXH7fHYnRGhQLZyi4uQqTpIi33gLbibBoFRN+B6KbQN5/fuPPuJbBbo1yqUI/ox+ID+3idEfWpA==",
+              "requires": {
+                "@babel/runtime": "^7.3.1",
+                "crypto-browserify": "3.12.0",
+                "eth-lib": "0.2.8",
+                "lodash": "^4.17.11",
+                "scrypt.js": "0.2.0",
+                "uuid": "3.3.2",
+                "web3-core": "1.0.0-beta.47",
+                "web3-core-helpers": "1.0.0-beta.47",
+                "web3-core-method": "1.0.0-beta.47",
+                "web3-providers": "1.0.0-beta.47",
+                "web3-utils": "1.0.0-beta.47"
+              }
+            },
+            "web3-eth-contract": {
+              "version": "1.0.0-beta.47",
+              "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.0.0-beta.47.tgz",
+              "integrity": "sha512-n9fShGnBoReei6IafpOrjhA+XGgjoCxIRHHanpe7MX6YQm/5ldDQMCpp7qCk4+XrgN5dk09cL/L1Tc1z3zHEjw==",
+              "requires": {
+                "@babel/runtime": "^7.3.1",
+                "lodash": "^4.17.11",
+                "web3-core": "1.0.0-beta.47",
+                "web3-core-helpers": "1.0.0-beta.47",
+                "web3-core-method": "1.0.0-beta.47",
+                "web3-core-promievent": "1.0.0-beta.47",
+                "web3-core-subscriptions": "1.0.0-beta.47",
+                "web3-eth-abi": "1.0.0-beta.47",
+                "web3-eth-accounts": "1.0.0-beta.47",
+                "web3-providers": "1.0.0-beta.47",
+                "web3-utils": "1.0.0-beta.47"
+              }
+            },
+            "web3-eth-ens": {
+              "version": "1.0.0-beta.47",
+              "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.0.0-beta.47.tgz",
+              "integrity": "sha512-gj6z6NCnew8VHIlDDG9eP1/WF5m1ri72NhYCIzsZ82kW1Bw9LBs0xw/zhimaRgAxnS7qcqHv8WJLa4w0A3QJ0Q==",
+              "requires": {
+                "@babel/runtime": "^7.3.1",
+                "eth-ens-namehash": "2.0.8",
+                "lodash": "^4.17.11",
+                "web3-core": "1.0.0-beta.47",
+                "web3-core-helpers": "1.0.0-beta.47",
+                "web3-core-method": "1.0.0-beta.47",
+                "web3-core-promievent": "1.0.0-beta.47",
+                "web3-eth-abi": "1.0.0-beta.47",
+                "web3-eth-contract": "1.0.0-beta.47",
+                "web3-net": "1.0.0-beta.47",
+                "web3-providers": "1.0.0-beta.47",
+                "web3-utils": "1.0.0-beta.47"
+              }
+            },
+            "web3-eth-iban": {
+              "version": "1.0.0-beta.47",
+              "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.0.0-beta.47.tgz",
+              "integrity": "sha512-/d0x+GG8BTyr9UovNLB6Rt5I6iYyn4Xj1/lGb2gHTffaFWD4StVevjeNEI8zTWrf2bEsb0xP6CjASQzNrQQVFQ==",
+              "requires": {
+                "@babel/runtime": "^7.3.1",
+                "bn.js": "4.11.8",
+                "web3-utils": "1.0.0-beta.47"
+              }
+            },
+            "web3-eth-personal": {
+              "version": "1.0.0-beta.47",
+              "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.0.0-beta.47.tgz",
+              "integrity": "sha512-0WzFdM2VCjIbbrNJu+VcNgbgsoq9RoKTUaAdLc7NjWv9szOqYgPphSjaThJ9v/EciLcIR/KFPN8DBYZ3gh4mWA==",
+              "requires": {
+                "@babel/runtime": "^7.3.1",
+                "web3-core": "1.0.0-beta.47",
+                "web3-core-helpers": "1.0.0-beta.47",
+                "web3-core-method": "1.0.0-beta.47",
+                "web3-net": "1.0.0-beta.47",
+                "web3-providers": "1.0.0-beta.47",
+                "web3-utils": "1.0.0-beta.47"
+              }
+            },
+            "web3-net": {
+              "version": "1.0.0-beta.47",
+              "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.0.0-beta.47.tgz",
+              "integrity": "sha512-3ywuCATkk5z9M4bv8/1TjgVDvR2LyuDqWhM39O1vlTor33cCb1SP1clmbS0j2BJe89QN+haxijTcSRQEsC8l0g==",
+              "requires": {
+                "@babel/runtime": "^7.3.1",
+                "lodash": "^4.17.11",
+                "web3-core": "1.0.0-beta.47",
+                "web3-core-helpers": "1.0.0-beta.47",
+                "web3-core-method": "1.0.0-beta.47",
+                "web3-providers": "1.0.0-beta.47",
+                "web3-utils": "1.0.0-beta.47"
+              }
+            },
+            "web3-providers": {
+              "version": "1.0.0-beta.47",
+              "resolved": "https://registry.npmjs.org/web3-providers/-/web3-providers-1.0.0-beta.47.tgz",
+              "integrity": "sha512-mgho0luErniheu6XHJr/kaSHWSDd7RwvGZUFbSX55j9U6UO5Qc4o/l8kPVafcab694XoF7HHFfAZ1KGKnnIbFw==",
+              "requires": {
+                "@babel/runtime": "^7.3.1",
+                "@types/node": "^10.12.18",
+                "eventemitter3": "3.1.0",
+                "lodash": "^4.17.11",
+                "oboe": "2.1.4",
+                "url-parse": "1.4.4",
+                "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
+                "xhr2-cookies": "1.1.0"
+              }
+            },
+            "web3-shh": {
+              "version": "1.0.0-beta.47",
+              "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.0.0-beta.47.tgz",
+              "integrity": "sha512-1ru6eruSN0zYV3S8cRnBb1PwciEvKbdhkcPStykYTvNiJ6juVS5E/Mbw7zscDjoaRwe/61w3OkE48utVjafNFw==",
+              "requires": {
+                "@babel/runtime": "^7.3.1",
+                "web3-core": "1.0.0-beta.47",
+                "web3-core-helpers": "1.0.0-beta.47",
+                "web3-core-method": "1.0.0-beta.47",
+                "web3-core-subscriptions": "1.0.0-beta.47",
+                "web3-net": "1.0.0-beta.47",
+                "web3-providers": "1.0.0-beta.47",
+                "web3-utils": "1.0.0-beta.47"
+              }
+            },
+            "web3-utils": {
+              "version": "1.0.0-beta.47",
+              "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.47.tgz",
+              "integrity": "sha512-Mn/n6qanKIi8uRGTYlqD55ZSRZjG8CsHE9CA6i8vLTn6PdRcKReJW1D4YNYTVAnNkyohkO4f4FSRtKE0DVa50w==",
+              "requires": {
+                "@babel/runtime": "^7.3.1",
+                "@types/bn.js": "^4.11.4",
+                "@types/node": "^10.12.18",
+                "bn.js": "4.11.8",
+                "eth-lib": "0.2.8",
+                "ethjs-unit": "^0.1.6",
+                "lodash": "^4.17.11",
+                "number-to-bn": "1.7.0",
+                "randomhex": "0.1.5",
+                "utf8": "2.1.1"
+              }
+            }
+          }
+        },
         "eth-lib": {
           "version": "0.2.8",
           "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
@@ -9388,6 +10588,16 @@
           "requires": {
             "http-https": "^1.0.0"
           }
+        },
+        "openzeppelin-solidity": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-2.1.3.tgz",
+          "integrity": "sha512-Zz595xw6w4ZrNU3JJJTlPd8bHFbHv5OkJlkqsM2i+NBs6CzImoHI3dZ+nmhkfR+p52cGXKmayAGbnfdCum1SMg=="
+        },
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
         },
         "scrypt-js": {
           "version": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "andromeda",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Consensus Smart Contracts",
   "main": "truffle.js",
   "directories": {
@@ -33,7 +33,7 @@
     "babel-register": "6.26.0",
     "bignumber.js": "7.2.1",
     "bip39": "2.5.0",
-    "contract-registry": "git+ssh://git@github.com/luciditytech/contract-registry.git#9c2fe02184f6ce70e836e03aee117ef27dfe7ec4",
+    "contract-registry": "git+ssh://git@github.com/luciditytech/contract-registry.git#4eaa0dd6d9c2d14d3bebbee40a546f1dda8eaba2",
     "digivice": "git+ssh://git@github.com/luciditytech/digivice.git#develop",
     "dotenv": "6.1.0",
     "ethereumjs-abi": "0.6.5",


### PR DESCRIPTION
- use `ContractRegistry` v0.1.1 to prevent storage locking
- when updating contract via `ContractRegistry`, old `Chain` contract is not killed

### Fix
- use `ContractRegistry` v0.1.1 to prevent storage locking

### Changed
- when updating contract via `ContractRegistry`, old contract is not killed

example:
by default old contracts were killed when we update them (https://ropsten.etherscan.io/address/0xb39af4565e292b69780059612557e361f9dbea51 - killed old `Chain`). 
After this change:
- https://ropsten.etherscan.io/address/0x82f92a5261953d16bb121c8ca8e22e0178a1a605 - old staging contract, that was not killed
- https://ropsten.etherscan.io/address/0x042f28f3d96aee14819ff34d0659a5edf7182caa - new contract (that uses the same storage as previous one).

we can read from both contracts, but only new one has right to write to storage.
This change is also needed if we need to deploy new contract with new storage. In that case old contract will stay intact and we can read archive data from it.